### PR TITLE
fixed numpy include dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import numpy as np
 from setuptools import setup, find_packages
 from Cython.Build import cythonize
 
@@ -30,6 +31,7 @@ setup(
         'Topic :: Scientific/Engineering',
     ],
     ext_modules = cythonize(['nnet/convnet/conv.pyx',
-                             'nnet/convnet/pool.pyx'])
+                             'nnet/convnet/pool.pyx']),
+    include_dirs = [np.get_include()]
 )
 


### PR DESCRIPTION
In setup.py added include_dirs so you don't run into an error including numpy/arrobject.h

http://stackoverflow.com/questions/14657375/cython-fatal-error-numpy-arrayobject-h-no-such-file-or-directory
